### PR TITLE
Initial Code of Conduct for discussion

### DIFF
--- a/conduct.html
+++ b/conduct.html
@@ -85,12 +85,12 @@
             <h2>Reporting</h2>
 
             <p>If you are being harassed by a member of our community, notice that someone else is being harassed, or
-                have any other concerns, please contact any of the conduct group who are in the @conduct Discord
+                have any other concerns, please contact any of the conduct group who are in the @mods Discord
                 group via Direct Message. If the person who is harassing you is on the conduct group, they will not be
                 involved in handling or resolving the incident.</p>
 
             <p>The conduct group will respond to any complaint as promptly as possible we can. If you do not get a
-                timely response (for example, if no members of the @conduct group are currently online) then please put
+                timely response (for example, if no members of the @mods group are currently online) then please put
                 your personal safety and well-being first, and consider logging out. Messages left for offline members
                 of the team on Discord will be responded to asynchronously as soon as possible.
             </p>

--- a/conduct.html
+++ b/conduct.html
@@ -33,7 +33,7 @@
             <h2>Toward a Welcoming and Safe Environment</h2>
 
             <p>We hope to create an environment in which diverse individuals can collaborate and interact in a positive
-                and affirming way. Examples of behavior that contributes to creating this sort of environment include:
+                and affirming way. Examples of behaviour that contributes to creating this sort of environment include:
             </p>
 
             <ul>
@@ -57,7 +57,7 @@
                 <li>Unwelcome comments regarding a person's lifestyle choices and practices, including those related to
                     food, health, parenting, relationships, drugs, and employment.</li>
                 <li>Deliberate misgendering, using inappropriate pronouns, or use of "dead" or rejected names.</li>
-                <li>Gratuitous or off-topic sexual images or behavior in spaces where they're not appropriate.</li>
+                <li>Gratuitous or off-topic sexual images or behaviour in spaces where they're not appropriate.</li>
                 <li>Physical contact and simulated physical contact (eg, textual descriptions like "hug" or "backrub")
                     without consent or after a request to stop.</li>
                 <li>Threats of violence.</li>
@@ -99,8 +99,9 @@
                 community outside our spaces, we still want to know about it. We will take all good-faith reports of
                 harassment by our members, especially the conduct group, seriously. This includes harassment outside
                 our spaces and harassment that took place at any point in time. The conduct group reserves the right to
-                exclude people from the community based on their past behavior, including behavior outside of our spaces
-                and behavior towards people who are not in this community.</p>
+                exclude people from the community based on their past behaviour, including behaviour outside of our
+                spaces
+                and behaviour towards people who are not in this community.</p>
 
             <p>In order to protect volunteers from abuse and burnout, we reserve the right to reject any report we
                 believe to have been made in bad faith. Reports intended to silence legitimate criticism may be
@@ -123,8 +124,8 @@
 
             <h2>Consequences</h2>
 
-            <p>Participants asked to stop any harassing behavior are expected to comply immediately. If a participant
-                engages in harassing behavior, the conduct group may take any action they deem appropriate, up to and
+            <p>Participants asked to stop any harassing behaviour are expected to comply immediately. If a participant
+                engages in harassing behaviour, the conduct group may take any action they deem appropriate, up to and
                 including expulsion from the community and identification of the participant as a harasser to other
                 members. At the discretion of the conduct group team, or by request, one or more of the parties involved
                 may request to discuss the violation and how to avoid similar situations in the future.</p>

--- a/conduct.html
+++ b/conduct.html
@@ -1,0 +1,155 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="UTF-8">
+    <title>Hacks 'R' Us</title>
+    <link rel="stylesheet" href="style.css">
+</head>
+
+<body>
+    <div class="container">
+        <h1><a href="/"><img src="img/logo.svg" alt="Hacks 'R' Us Logo"></a></h1>
+        <p>In addition to the informal fun-governing Hacks 'R' Us <a href="/#policy">Policy</a>, we also all agree to
+            follow and respect our Code of Conduct, a derivative of <a href="https://community-covenant.net/">Community
+                Covenant</a>.</p>
+        <div class="code-of-conduct">
+            <h1>Community Covenant</h1>
+
+            <h2>Our Goal</h2>
+
+            <p>This community is dedicated to providing a harassment-free experience for everyone. We do not tolerate
+                harassment of participants in any form.</p>
+
+            <h2>Applicability and Scope</h2>
+
+            <p>This code of conduct applies to all of this community's spaces, including public channels, private
+                channels and direct messages, both online and off. Anyone who violates this code of conduct may be
+                sanctioned or expelled from these spaces at the discretion of the administrators.</p>
+
+            <p>Where the community's Policy and this Code of Conduct could be seen to be in conflict, this Code of
+                Conduct takes precedence.</p>
+
+            <h2>Toward a Welcoming and Safe Environment</h2>
+
+            <p>We hope to create an environment in which diverse individuals can collaborate and interact in a positive
+                and affirming way. Examples of behavior that contributes to creating this sort of environment include:
+            </p>
+
+            <ul>
+                <li>Using welcoming and inclusive language</li>
+                <li>Being respectful of differing viewpoints and experiences</li>
+                <li>Gracefully accepting constructive criticism</li>
+                <li>Focusing on what is best for the overall community</li>
+                <li>Showing empathy towards other community members</li>
+            </ul>
+
+            <h2>Anti-Harassment Statement</h2>
+
+            <p>This community will not tolerate harassment of any kind. Examples of harassment include:</p>
+
+            <ul>
+                <li>Offensive comments related to gender, gender identity and expression, sexual orientation,
+                    disability, mental illness, neuro(a)typicality, physical appearance, pregnancy status, veteran
+                    status, political affiliation, marital status, body size, age, race, national origin, ethnic origin,
+                    nationality, immigration status, language, religion or lack thereof, or other identity marker. This
+                    includes anti-Indigenous/Nativeness and anti-Blackness.</li>
+                <li>Unwelcome comments regarding a person's lifestyle choices and practices, including those related to
+                    food, health, parenting, relationships, drugs, and employment.</li>
+                <li>Deliberate misgendering, using inappropriate pronouns, or use of "dead" or rejected names.</li>
+                <li>Gratuitous or off-topic sexual images or behavior in spaces where they're not appropriate.</li>
+                <li>Physical contact and simulated physical contact (eg, textual descriptions like "hug" or "backrub")
+                    without consent or after a request to stop.</li>
+                <li>Threats of violence.</li>
+                <li>Incitement of violence towards any individual or group, including encouraging a person to commit
+                    suicide or to engage in self-harm.</li>
+                <li>Deliberate intimidation.</li>
+                <li>Stalking or following - online or in the physical world.</li>
+                <li>Harassing photography or recording, including logging online activity for harassment purposes.</li>
+                <li>Sustained disruption of discussion.</li>
+                <li>Unwelcome sexual attention.</li>
+                <li>Patterns of inappropriate social contact, such as requesting/assuming inappropriate levels of
+                    intimacy with others.</li>
+                <li>Continued one-on-one communication after requests to cease.</li>
+                <li>Deliberate "outing" of any aspect of a person's identity without their consent except as necessary
+                    to protect vulnerable people from intentional abuse.</li>
+                <li>Publication of non-harassing private communication.</li>
+                <li>Jokes that resemble the above, such as "hipster racism", still count as harassment even if meant
+                    satirically or ironically.</li>
+            </ul>
+
+            <p>If you have questions or concerns about these issues please feel free to message a member of the conduct
+                group, ask in the #policy channel, or ask for an opportunity to explore the issue with a moderator and
+                volunteers.</p>
+
+            <h2>Reporting</h2>
+
+            <p>If you are being harassed by a member of our community, notice that someone else is being harassed, or
+                have any other concerns, please contact any of the conduct group who are in the @conduct Discord
+                group via Direct Message. If the person who is harassing you is on the conduct group, they will not be
+                involved in handling or resolving the incident.</p>
+
+            <p>The conduct group will respond to any complaint as promptly as possible we can. If you do not get a
+                timely response (for example, if no members of the @conduct group are currently online) then please put
+                your personal safety and well-being first, and consider logging out. Messages left for offline members
+                of the team on Discord will be responded to asynchronously as soon as possible.
+            </p>
+
+            <p>This code of conduct applies to our community's spaces, but if you are being harassed by a member of our
+                community outside our spaces, we still want to know about it. We will take all good-faith reports of
+                harassment by our members, especially the conduct group, seriously. This includes harassment outside
+                our spaces and harassment that took place at any point in time. The conduct group reserves the right to
+                exclude people from the community based on their past behavior, including behavior outside of our spaces
+                and behavior towards people who are not in this community.</p>
+
+            <p>In order to protect volunteers from abuse and burnout, we reserve the right to reject any report we
+                believe to have been made in bad faith. Reports intended to silence legitimate criticism may be
+                disregarded without response.</p>
+
+            <h2>Enforcement Process</h2>
+
+            <p>Every code of conduct violation report will be treated with seriousness and care. If a member's immediate
+                safety and security is threatened, an individual conduct group member may take any action that they deem
+                appropriate, up to and including temporarily banning the offender from the community. In less urgent
+                situations, at least two conduct group members will discuss the offense and mutually arrive at a
+                suitable response, which will be shared with the offender privately. Whatever the resolution that they
+                decide upon, the decision of the conduct group members involved in a violation case will be considered
+                final.</p>
+
+            <p>We will respect confidentiality requests for the purpose of protecting victims of abuse. At our
+                discretion, we may publicly name a person about whom we've received harassment complaints, or privately
+                warn third parties about them, if we believe that doing so will increase the safety of our members or
+                the general public. We will not name harassment victims without their affirmative consent.</p>
+
+            <h2>Consequences</h2>
+
+            <p>Participants asked to stop any harassing behavior are expected to comply immediately. If a participant
+                engages in harassing behavior, the conduct group may take any action they deem appropriate, up to and
+                including expulsion from the community and identification of the participant as a harasser to other
+                members. At the discretion of the conduct group team, or by request, one or more of the parties involved
+                may request to discuss the violation and how to avoid similar situations in the future.</p>
+
+            <h2>Acknowledgements</h2>
+
+            <p>This Code of Conduct is adapted from the Community Covenant
+                (<a href="https://community-covenant.net">https://community-covenant.net</a>), version 1.0, available at
+                <a href="https://community-covenant.net/version/1/0/">https://community-covenant.net/version/1/0/</a>.
+                The Community Covenant is an open source effort and is built on codes of conduct that came before it,
+                including the <a href="https://contributor-covenant.org/">Contributor Covenant</a> and the
+                <a href="https://lgbtq.technology/coc.html">LGBTQ in Tech community code of conduct</a>.</p>
+
+            <h2>License</h2>
+
+            <p><span xmlns:dct="http://purl.org/dc/terms/" href="https://purl.org/dc/dcmitype/Text" property="dct:title"
+                    rel="dct:type">Community Covenant</span> by <a xmlns:cc="http://creativecommons.org/ns#"
+                    href="http://community-covenant.net/" property="cc:attributionName" rel="cc:attributionURL">Coraline
+                    Ada Ehmke</a> is licensed under a <a rel="license"
+                    href="http://creativecommons.org/licenses/by/4.0/">Creative Commons Attribution 4.0 International
+                    License</a>.<br />Based on a work at <a xmlns:dct="http://purl.org/dc/terms/"
+                    href="http://community-covenant.net/latest/" rel="dct:source">http://community-covenant.net/</a>.
+            </p>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/index.html
+++ b/index.html
@@ -1,10 +1,12 @@
 <!DOCTYPE html>
 <html lang="en">
+
 <head>
 	<meta charset="UTF-8">
 	<title>Hacks 'R' Us</title>
 	<link rel="stylesheet" href="style.css">
 </head>
+
 <body>
 	<div class="container">
 		<h1><a href="/"><img src="img/logo.svg" alt="Hacks 'R' Us Logo"></a></h1>
@@ -36,6 +38,8 @@
 			<li><a href="https://emfcamp.org">EMF2022</a></li>
 		</ul>
 		<h2 id='policy'>Policy</h2>
+		<p>For more formal information, the <a href="/conduct.html">Code of Conduct</a> may be relevant to your
+			interests.</p>
 		<ol class="left-aligned nested parent">
 			<li>No one shall dissuade or stop anyone from making anything, especially if it's a bad idea.</li>
 			<li>"Fuck it, we'll do it live" is always acceptable.</li>
@@ -45,7 +49,8 @@
 				<li>Un defined, (but positive) number of ✅ are needed for policy approvals.</li>
 				<li>Ticks must outweigh ❌ votes</li>
 			</ol>
-			<li>No hacker shall intentionally set another hacker on fire, or through inaction allow another hacker to be set on fire.</li>
+			<li>No hacker shall intentionally set another hacker on fire, or through inaction allow another hacker to be
+				set on fire.</li>
 			<li>For the avoidance of doubt, explosions are a type of fire.</li>
 			<li>Disputes between members will be settled non-violently through a game of Guess Who?</li>
 			<li>Policy items in <blink>&lt;blink&gt;</blink> tags are only in effect whilst visible.</li>
@@ -61,4 +66,5 @@
 		}
 	</script>
 </body>
+
 </html>

--- a/style.css
+++ b/style.css
@@ -101,6 +101,10 @@ ul.fisher-price-links>li>a {
 	right: 10px;
 }
 
+div.code-of-conduct>p, div.code-of-conduct>ul {
+	text-align: left;
+}
+
 @keyframes unicornMode {
 	from {
 		color: #6666ff;


### PR DESCRIPTION
Changes deviating from the community covenant template:
1. Additions of 'u' in multiple words.
1. Replacement of 'Administrator' references with 'conduct group' to note we ultimately need to have persons who hold this role but otherwise have no leadership ability above other members.
1. Removal of email contact and statement that Discord messages regarding reports will be responded to asynchronously.
1. Statement that the CoC supersedes the Policy when there is a conflict.
1. Movement of the links to be https.
1. Changed "deleted without response" to disregarded because you can't delete things on the internet.
1. Added #policy channel for place to discuss issues with the CoC.

Note that in order to correctly implement this process, we require a new discord group, `@conduct` (or we can rename `@cuties` or something and use that), which must at all times have at least three active members so that a report regarding one of its members can be handled by the other two.